### PR TITLE
package/hss-payload-generator: Fix rpath not passed to linker as expe…

### DIFF
--- a/package/hss-payload-generator/hss-payload-generator.mk
+++ b/package/hss-payload-generator/hss-payload-generator.mk
@@ -18,7 +18,7 @@ endif
 define HOST_HSS_PAYLOAD_GENERATOR_BUILD_CMDS
 	$(MAKE) -C $(@D)/tools/hss-payload-generator \
 		HOST_INCLUDES="$(HOST_CPPFLAGS)" \
-		LDFLAGS=$(HOST_LDFLAGS)
+		LDFLAGS="$(HOST_LDFLAGS)"
 
 	cp $(BR2_PACKAGE_HOST_HSS_PAYLOAD_GENERATOR_SRC) \
 		$(@D)/tools/hss-payload-generator/src.bin


### PR DESCRIPTION
The rpath option is not passed to linker as expected, which leads to hss-payload-generator failing to be run.

Error during build prior to the patch:
```shell
WARNING: no hash file for hss-payload-generator-2023.09.tar.gz
>>> host-hss-payload-generator 2023.09 Extracting
gzip -d -c /home/rajkumarr/workspace/tii/sel4/buildroot/dl/hss-payload-generator/hss-payload-generator-2023.09.tar.gz | tar --strip-components=1 -C /home/rajkumarr/workspace/tii/sel4/buildroot/output/build/host-hss-payload-generator-2023.09   -xf -
>>> host-hss-payload-generator 2023.09 Patching
>>> host-hss-payload-generator 2023.09 Configuring
>>> host-hss-payload-generator 2023.09 Building
/usr/bin/make  -C /home/rajkumarr/workspace/tii/sel4/buildroot/output/build/host-hss-payload-generator-2023.09/tools/hss-payload-generator HOST_INCLUDES="-I/home/rajkumarr/workspace/tii/sel4/buildroot/output/host/include" LDFLAGS=-L/home/rajkumarr/workspace/tii/sel4/buildroot/output/host/lib -Wl,-rpath,/home/rajkumarr/workspace/tii/sel4/buildroot/output/host/lib
 CC        /home/rajkumarr/workspace/tii/sel4/buildroot/output/build/host-hss-payload-generator-2023.09/tools/hss-payload-generator/main.o
 CC        /home/rajkumarr/workspace/tii/sel4/buildroot/output/build/host-hss-payload-generator-2023.09/tools/hss-payload-generator/yaml_parser.o
 CC        /home/rajkumarr/workspace/tii/sel4/buildroot/output/build/host-hss-payload-generator-2023.09/tools/hss-payload-generator/blob_handler.o
 CC        /home/rajkumarr/workspace/tii/sel4/buildroot/output/build/host-hss-payload-generator-2023.09/tools/hss-payload-generator/elf_parser.o
 CC        /home/rajkumarr/workspace/tii/sel4/buildroot/output/build/host-hss-payload-generator-2023.09/tools/hss-payload-generator/elf_strings.o
 CC        /home/rajkumarr/workspace/tii/sel4/buildroot/output/build/host-hss-payload-generator-2023.09/tools/hss-payload-generator/crc32.o
 CC        /home/rajkumarr/workspace/tii/sel4/buildroot/output/build/host-hss-payload-generator-2023.09/tools/hss-payload-generator/generate_payload.o
 CC        /home/rajkumarr/workspace/tii/sel4/buildroot/output/build/host-hss-payload-generator-2023.09/tools/hss-payload-generator/dump_payload.o
 CC        /home/rajkumarr/workspace/tii/sel4/buildroot/output/build/host-hss-payload-generator-2023.09/tools/hss-payload-generator/debug_printf.o
 LD        /home/rajkumarr/workspace/tii/sel4/buildroot/output/build/host-hss-payload-generator-2023.09/tools/hss-payload-generator/hss-payload-generator
cp "/home/rajkumarr/workspace/tii/sel4/buildroot/output/images/u-boot.bin" /home/rajkumarr/workspace/tii/sel4/buildroot/output/build/host-hss-payload-generator-2023.09/tools/hss-payload-generator/src.bin
( if [ "" = "y" ]; then cp /home/rajkumarr/workspace/tii/sel4/buildroot/output/images/mpfs-rpmsg-remote.elf /home/rajkumarr/workspace/tii/sel4/buildroot/output/build/host-hss-payload-generator-2023.09/tools/hss-payload-generator/amp.elf; fi; cd /home/rajkumarr/workspace/tii/sel4/buildroot/output/build/host-hss-payload-generator-2023.09/tools/hss-payload-generator; ./hss-payload-generator -c "/home/rajkumarr/workspace/tii/sel4/buildroot-external-microchip/board/microchip/icicle/config.yaml" -v /home/rajkumarr/workspace/tii/sel4/buildroot/output/images/payload.bin; )
./hss-payload-generator: error while loading shared libraries: libcrypto.so.1.1: cannot open shared object file: No such file or directory
make[1]: *** [package/pkg-generic.mk:292: /home/rajkumarr/workspace/tii/sel4/buildroot/output/build/host-hss-payload-generator-2023.09/.stamp_built] Error 127
make: *** [Makefile:84: _all] Error 2
rajkumarr@TII-RRAMASAMY-LX:~/workspace/tii/sel4/buildroot$ 
``` 