### PR TITLE
Point HSS payload generator at correct dynamic libraries

### DIFF
--- a/package/hss-payload-generator/hss-payload-generator.mk
+++ b/package/hss-payload-generator/hss-payload-generator.mk
@@ -29,6 +29,7 @@ define HOST_HSS_PAYLOAD_GENERATOR_BUILD_CMDS
 				$(@D)/tools/hss-payload-generator/amp.elf; \
 		fi; \
 		cd $(@D)/tools/hss-payload-generator; \
+		LD_LIBRARY_PATH=$(HOST_DIR)/lib:$(LD_LIBRARY_PATH) \
 		./hss-payload-generator \
 			-c $(BR2_PACKAGE_HOST_HSS_PAYLOAD_GENERATOR_CFG) \
 			-v $(BINARIES_DIR)/payload.bin; \


### PR DESCRIPTION
When running the HSS payload generator on newer Ubuntu distributions (Ubuntu 23.10 in my case), OpenSSL 1.1 is no longer available. However, the hss-payload-generator binary is dynamically linked against this library, which is built by Buildroot. However, the path to the library is not correctly passed at runtime. This PR addresses this.