### PR TITLE
Add package for HSS (v2)

### DIFF
--- a/Config.in
+++ b/Config.in
@@ -45,3 +45,5 @@ source "$BR2_EXTERNAL_MCHP_PATH/system/Config.in"
 source "$BR2_EXTERNAL_MCHP_PATH/package/libosmscout/Config.in"
 
 source "$BR2_EXTERNAL_MCHP_PATH/package/video-capture-at91/Config.in"
+
+source "$BR2_EXTERNAL_MCHP_PATH/boot/hss/Config.in"

--- a/boot/hss/Config.in
+++ b/boot/hss/Config.in
@@ -1,0 +1,10 @@
+config BR2_TARGET_HSS
+        bool "Microchip HSS"
+
+config BR2_TARGET_HSS_SC_INSTALL_DIR
+        string "SoftConsole install location"
+        depends on BR2_TARGET_HSS
+
+config BR2_TARGET_HSS_FPGENPROG
+        string "fpgenprog location"
+        depends on BR2_TARGET_HSS

--- a/boot/hss/Config.in
+++ b/boot/hss/Config.in
@@ -1,10 +1,2 @@
 config BR2_TARGET_HSS
         bool "Microchip HSS"
-
-config BR2_TARGET_HSS_SC_INSTALL_DIR
-        string "SoftConsole install location"
-        depends on BR2_TARGET_HSS
-
-config BR2_TARGET_HSS_FPGENPROG
-        string "fpgenprog location"
-        depends on BR2_TARGET_HSS

--- a/boot/hss/hss.mk
+++ b/boot/hss/hss.mk
@@ -27,7 +27,7 @@ define HSS_BUILD_CMDS
 	$(MAKE) $(HSS_MAKE_OPTS) -C $(@D)
 endef
 
-define HSS_INSTALL_CMDS
+define HSS_INSTALL_TARGET_CMDS
 	$(INSTALL) -m 0644 -D $(@D)/Default/hss-envm-wrapper.bin $(BINARIES_DIR)/hss-envm-wrapper.bin
 	$(INSTALL) -m 0644 -D $(@D)/Default/hss-l2scratch.bin $(BINARIES_DIR)/hss-l2scratch.bin
 endef

--- a/boot/hss/hss.mk
+++ b/boot/hss/hss.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-HSS_VERSION = v2023.02.1
+HSS_VERSION = v2023.06
 HSS_SITE = $(call github,polarfire-soc,hart-software-services,$(HSS_VERSION))
 
 ifeq ($(BR2_TARGET_HSS_SC_INSTALL_DIR),)

--- a/boot/hss/hss.mk
+++ b/boot/hss/hss.mk
@@ -7,20 +7,12 @@
 HSS_VERSION = v2023.06
 HSS_SITE = $(call github,polarfire-soc,hart-software-services,$(HSS_VERSION))
 
-ifeq ($(BR2_TARGET_HSS_SC_INSTALL_DIR),)
-	$(error BR2_TARGET_HSS_SC_INSTALL_DIR must be defined)
-endif
-
-ifeq ($(BR2_TARGET_HSS_FPGENPROG),)
-	$(error BR2_TARGET_HSS_FPGENPROG must be defined)
-endif
-
-SOFTCONSOLE = $(BR2_TARGET_HSS_SC_INSTALL_DIR)
-HSS_MAKE_OPTS += BOARD=mpfs-icicle-kit-es SC_INSTALL_DIR=$(SOFTCONSOLE) FPGENPROG=$(BR2_TARGET_HSS_FPGENPROG) \
-                  PATH=$(SOFTCONSOLE)/riscv-unknown-elf-gcc/bin:$(BR_PATH)
+HSS_MAKE_OPTS += BOARD=mpfs-icicle-kit-es CROSS_COMPILE=riscv64-buildroot-linux-gnu- \
+                   PLATFORM_CFLAGS="-fno-pic" PATH=$(BR_PATH)
 
 define HSS_CONFIGURE_CMDS
 	cp $(@D)/boards/mpfs-icicle-kit-es/def_config $(@D)/.config
+	ln -sf $(STAGING_DIR)/usr/include/gnu/stubs-{lp64d.h,lp64.h}
 endef
 
 define HSS_BUILD_CMDS

--- a/boot/hss/hss.mk
+++ b/boot/hss/hss.mk
@@ -1,0 +1,35 @@
+################################################################################
+#
+# HSS
+#
+################################################################################
+
+HSS_VERSION = v2023.02.1
+HSS_SITE = $(call github,polarfire-soc,hart-software-services,$(HSS_VERSION))
+
+ifeq ($(BR2_TARGET_HSS_SC_INSTALL_DIR),)
+	$(error BR2_TARGET_HSS_SC_INSTALL_DIR must be defined)
+endif
+
+ifeq ($(BR2_TARGET_HSS_FPGENPROG),)
+	$(error BR2_TARGET_HSS_FPGENPROG must be defined)
+endif
+
+SOFTCONSOLE = $(BR2_TARGET_HSS_SC_INSTALL_DIR)
+HSS_MAKE_OPTS += BOARD=mpfs-icicle-kit-es SC_INSTALL_DIR=$(SOFTCONSOLE) FPGENPROG=$(BR2_TARGET_HSS_FPGENPROG) \
+                  PATH=$(SOFTCONSOLE)/riscv-unknown-elf-gcc/bin:$(BR_PATH)
+
+define HSS_CONFIGURE_CMDS
+	cp $(@D)/boards/mpfs-icicle-kit-es/def_config $(@D)/.config
+endef
+
+define HSS_BUILD_CMDS
+	$(MAKE) $(HSS_MAKE_OPTS) -C $(@D)
+endef
+
+define HSS_INSTALL_CMDS
+	$(INSTALL) -m 0644 -D $(@D)/Default/hss-envm-wrapper.bin $(BINARIES_DIR)/hss-envm-wrapper.bin
+	$(INSTALL) -m 0644 -D $(@D)/Default/hss-l2scratch.bin $(BINARIES_DIR)/hss-l2scratch.bin
+endef
+
+$(eval $(generic-package))

--- a/external.mk
+++ b/external.mk
@@ -1,4 +1,5 @@
 include $(sort $(wildcard $(BR2_EXTERNAL_MCHP_PATH)/package/*/*.mk))
+include $(sort $(wildcard $(BR2_EXTERNAL_MCHP_PATH)/boot/*/*.mk))
 
 # add libm2d as a dependency of cairo when it is enabled
 ifeq ($(BR2_PACKAGE_LIBM2D),y)


### PR DESCRIPTION
Following up on #6 a few months ago, I figured I would send this to you in case you are interested. I've done some work to decouple having SoftConsole installed and building the HSS, primarily due to this feedback from the last iteration of these changes:

```
We believe building an Linux image with Buildroot/Yocto shouldn't depend on SoftConsole or Libero being installed in the system.
```

I've been running this for a few months without any encountered problems in the HSS